### PR TITLE
Rename `--public-key-file` to `--pgp-public-key-file`

### DIFF
--- a/README-QWIKLABS.md
+++ b/README-QWIKLABS.md
@@ -407,7 +407,7 @@ Add the PGP Key to the Attestor:
 gcloud --project="${PROJECT_ID}" \
     beta container binauthz attestors public-keys add \
     --attestor="${ATTESTOR}" \
-    --public-key-file="${PGP_PUB_KEY}"
+    --pgp-public-key-file="${PGP_PUB_KEY}"
 ```
 
 List the newly created Attestor:


### PR DESCRIPTION
running
```
gcloud --project="${PROJECT_ID}" \
     beta container binauthz attestors public-keys add \
     --attestor="${ATTESTOR}" \
     --public-key-file="${PGP_PUB_KEY}"
```

throws:

```
ERROR: (gcloud.beta.container.binauthz.attestors.public-keys.add) unrecognized arguments: --public-key-file=generated-key.pgp (did you mean '--pgp-public-key-file'?)
To search the help text of gcloud commands, run:
  gcloud help -- SEARCH_TERMS
```

this is the correct command:

```
gcloud --project="${PROJECT_ID}"     beta container binauthz attestors public-keys add     -
-attestor="${ATTESTOR}"     --pgp-public-key-file="${PGP_PUB_KEY}"
```