### PR TITLE
Rename `--pgp-key-fingerprint` argument to `--public-key-id`

### DIFF
--- a/README-QWIKLABS.md
+++ b/README-QWIKLABS.md
@@ -488,7 +488,7 @@ gcloud beta container binauthz attestations create \
     --artifact-url="${IMAGE_PATH}@${IMAGE_DIGEST}" \
     --attestor="projects/${PROJECT_ID}/attestors/${ATTESTOR}" \
     --signature-file=${GENERATED_SIGNATURE} \
-    --pgp-key-fingerprint="${PGP_FINGERPRINT}"
+    --public-key-id="${PGP_FINGERPRINT}"
 ```
 
 View the newly created attestation:


### PR DESCRIPTION
Running
```
gcloud beta container binauthz attestations create \
    --artifact-url="${IMAGE_PATH}@${IMAGE_DIGEST}" \
    --attestor="projects/${PROJECT_ID}/attestors/${ATTESTOR}" \
    --signature-file=${GENERATED_SIGNATURE} \
    --pgp-key-fingerprint="${PGP_FINGERPRINT}"
```

throws this error:

```
ERROR: (gcloud.beta.container.binauthz.attestations.create) unrecognized arguments: --pgp-key-fingerprint=AAAA0000000000000000FFFFFFFFFFFFFFFFFFFF
```

This is an example from `gcloud beta container binauthz attestations create --help`

```
$ gcloud beta container binauthz attestations create \
    --project=my_proj \
    --artifact-url='gcr.io/example-project/example-image@sha256:abcd' \
    --attestor=projects/foo/attestors/bar \
    --signature-file=signed_artifact_attestation.pgp.sig \
    --public-key-id=AAAA0000000000000000FFFFFFFFFFFFFFFFFFFF
```

This pull request fixes the command in qwiklabs readme file