### PR TITLE
Updating JSON payload for Attestation Note

### DIFF
--- a/README-QWIKLABS.md
+++ b/README-QWIKLABS.md
@@ -340,7 +340,7 @@ Create the `ATTESTATION` note payload:
 cat > ${NOTE_PAYLOAD_PATH} << EOF
 {
   "name": "projects/${PROJECT_ID}/notes/${NOTE_ID}",
-  "attestation_authority": {
+  "attestation": {
     "hint": {
       "human_readable_name": "${NOTE_DESC}"
     }

--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ Create the `ATTESTATION` note payload:
 cat > ${NOTE_PAYLOAD_PATH} << EOF
 {
   "name": "projects/${PROJECT_ID}/notes/${NOTE_ID}",
-  "attestation_authority": {
+  "attestation": {
     "hint": {
       "human_readable_name": "${NOTE_DESC}"
     }


### PR DESCRIPTION
JSON payload for Attestation Note was using v1beta1 API `attestation_authority` which made the exercise of posting the note fail with an error `unknown JSON payload received`. Now that the container analysis `v1` API is [available](https://cloud.google.com/container-registry/docs/reference/rest/v1/projects.notes#Note), I updated the JSON representation for the Attestation Note to simply use `attestation`. 