### PR TITLE
Issue#27 Remove discontinued Beta version for Binary Authorization API

### DIFF
--- a/README-QWIKLABS.md
+++ b/README-QWIKLABS.md
@@ -356,14 +356,14 @@ curl -X POST \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer $(gcloud auth print-access-token)"  \
     --data-binary @${NOTE_PAYLOAD_PATH}  \
-    "https://containeranalysis.googleapis.com/v1beta1/projects/${PROJECT_ID}/notes/?noteId=${NOTE_ID}"
+    "https://containeranalysis.googleapis.com/v1/projects/${PROJECT_ID}/notes/?noteId=${NOTE_ID}"
 ```
 
 You should see the output from the prior command display the created note, but the following command will also list the created note:
 
 ```console
 curl -H "Authorization: Bearer $(gcloud auth print-access-token)"  \
-    "https://containeranalysis.googleapis.com/v1beta1/projects/${PROJECT_ID}/notes/${NOTE_ID}"
+    "https://containeranalysis.googleapis.com/v1/projects/${PROJECT_ID}/notes/${NOTE_ID}"
 ```
 
 ##### Creating a PGP Signing Key
@@ -613,7 +613,7 @@ Delete the Container Analysis note:
 ```console
 curl -X DELETE \
     -H "Authorization: Bearer $(gcloud auth print-access-token)" \
-    "https://containeranalysis.googleapis.com/v1beta1/projects/${PROJECT_ID}/notes/${NOTE_ID}"
+    "https://containeranalysis.googleapis.com/v1/projects/${PROJECT_ID}/notes/${NOTE_ID}"
 ```
 
 ## Troubleshooting

--- a/README-QWIKLABS.md
+++ b/README-QWIKLABS.md
@@ -135,9 +135,9 @@ To access the Binary Authorization Policy configuration UI, perform the followin
 
 To access the Binary Authorization Policy configuration via `gcloud`:
 
-* Run `gcloud beta container binauthz policy export > policy.yaml`
+* Run `gcloud container binauthz policy export > policy.yaml`
 * Make the necessary edits to `policy.yaml`
-* Run `gcloud beta container binauthz policy import policy.yaml`
+* Run `gcloud container binauthz policy import policy.yaml`
 
 The policy you are editing is the "default" policy, and it applies to *all GKE clusters in the GCP project* unless a cluster-specific policy is in place.  The recommendation is to create policies specific to each cluster and achieve successful operation (whitelisting registries as needed), and then set the default project-level policy to "Deny All Images".  Any new cluster in this project will then need its own cluster-specific policy.
 
@@ -396,7 +396,7 @@ Create the Attestor in the Binary Authorization API:
 
 ```console
 gcloud --project="${PROJECT_ID}" \
-    beta container binauthz attestors create "${ATTESTOR}" \
+    container binauthz attestors create "${ATTESTOR}" \
     --attestation-authority-note="${NOTE_ID}" \
     --attestation-authority-note-project="${PROJECT_ID}"
 ```
@@ -405,7 +405,7 @@ Add the PGP Key to the Attestor:
 
 ```console
 gcloud --project="${PROJECT_ID}" \
-    beta container binauthz attestors public-keys add \
+    container binauthz attestors public-keys add \
     --attestor="${ATTESTOR}" \
     --pgp-public-key-file="${PGP_PUB_KEY}"
 ```
@@ -414,7 +414,7 @@ List the newly created Attestor:
 
 ```console
 gcloud --project="${PROJECT_ID}" \
-    beta container binauthz attestors list
+    container binauthz attestors list
 ```
 
 The output should look similar to the following:
@@ -456,7 +456,7 @@ IMAGE_DIGEST="$(gcloud container images list-tags --format='get(digest)' $IMAGE_
 Create a JSON-formatted signature payload:
 
 ```console
-gcloud beta container binauthz create-signature-payload \
+gcloud container binauthz create-signature-payload \
     --artifact-url="${IMAGE_PATH}@${IMAGE_DIGEST}" > ${GENERATED_PAYLOAD}
 ```
 
@@ -484,7 +484,7 @@ cat "${GENERATED_SIGNATURE}"
 Create the attestation:
 
 ```console
-gcloud beta container binauthz attestations create \
+gcloud container binauthz attestations create \
     --artifact-url="${IMAGE_PATH}@${IMAGE_DIGEST}" \
     --attestor="projects/${PROJECT_ID}/attestors/${ATTESTOR}" \
     --signature-file=${GENERATED_SIGNATURE} \
@@ -494,7 +494,7 @@ gcloud beta container binauthz attestations create \
 View the newly created attestation:
 
 ```console
-gcloud beta container binauthz attestations list \
+gcloud container binauthz attestations list \
     --attestor="projects/${PROJECT_ID}/attestors/${ATTESTOR}"
 ```
 
@@ -605,7 +605,7 @@ Delete the Attestor:
 
 ```console
 gcloud --project="${PROJECT_ID}" \
-    beta container binauthz attestors delete "${ATTESTOR}"
+    container binauthz attestors delete "${ATTESTOR}"
 ```
 
 Delete the Container Analysis note:

--- a/README.md
+++ b/README.md
@@ -200,9 +200,9 @@ To access the Binary Authorization Policy configuration UI, perform the followin
 
 To access the Binary Authorization Policy configuration via `gcloud`:
 
-* Run `gcloud beta container binauthz policy export > policy.yaml`
+* Run `gcloud container binauthz policy export > policy.yaml`
 * Make the necessary edits to `policy.yaml`
-* Run `gcloud beta container binauthz policy import policy.yaml`
+* Run `gcloud container binauthz policy import policy.yaml`
 
 The policy you are editing is the "default" policy, and it applies to *all GKE clusters in the GCP project* unless a cluster-specific policy is in place.  The recommendation is to create policies specific to each cluster and achieve successful operation (whitelisting registries as needed), and then set the default project-level policy to "Deny All Images".  Any new cluster in this project will then need its own cluster-specific policy.
 
@@ -461,7 +461,7 @@ Create the Attestor in the Binary Authorization API:
 
 ```console
 gcloud --project="${PROJECT_ID}" \
-    beta container binauthz attestors create "${ATTESTOR}" \
+    container binauthz attestors create "${ATTESTOR}" \
     --attestation-authority-note="${NOTE_ID}" \
     --attestation-authority-note-project="${PROJECT_ID}"
 ```
@@ -470,7 +470,7 @@ Add the PGP Key to the Attestor:
 
 ```console
 gcloud --project="${PROJECT_ID}" \
-    beta container binauthz attestors public-keys add \
+    container binauthz attestors public-keys add \
     --attestor="${ATTESTOR}" \
     --public-key-file="${PGP_PUB_KEY}"
 ```
@@ -479,7 +479,7 @@ List the newly created Attestor:
 
 ```console
 gcloud --project="${PROJECT_ID}" \
-    beta container binauthz attestors list
+    container binauthz attestors list
 ```
 
 The output should look similar to the following:
@@ -521,7 +521,7 @@ IMAGE_DIGEST="$(gcloud container images list-tags --format='get(digest)' $IMAGE_
 Create a JSON-formatted signature payload:
 
 ```console
-gcloud beta container binauthz create-signature-payload \
+gcloud container binauthz create-signature-payload \
     --artifact-url="${IMAGE_PATH}@${IMAGE_DIGEST}" > ${GENERATED_PAYLOAD}
 ```
 
@@ -549,7 +549,7 @@ cat "${GENERATED_SIGNATURE}"
 Create the attestation:
 
 ```console
-gcloud beta container binauthz attestations create \
+gcloud container binauthz attestations create \
     --artifact-url="${IMAGE_PATH}@${IMAGE_DIGEST}" \
     --attestor="projects/${PROJECT_ID}/attestors/${ATTESTOR}" \
     --signature-file=${GENERATED_SIGNATURE} \
@@ -559,7 +559,7 @@ gcloud beta container binauthz attestations create \
 View the newly created attestation:
 
 ```console
-gcloud beta container binauthz attestations list \
+gcloud container binauthz attestations list \
     --attestor="projects/${PROJECT_ID}/attestors/${ATTESTOR}"
 ```
 
@@ -670,7 +670,7 @@ Delete the Attestor:
 
 ```console
 gcloud --project="${PROJECT_ID}" \
-    beta container binauthz attestors delete "${ATTESTOR}"
+    container binauthz attestors delete "${ATTESTOR}"
 ```
 
 Delete the Container Analysis note:

--- a/create.sh
+++ b/create.sh
@@ -41,9 +41,8 @@ enable_project_api "${PROJECT}" "containeranalysis.googleapis.com"
 enable_project_api "${PROJECT}" "binaryauthorization.googleapis.com"
 
 # Create a 2-node zonal GKE cluster
-# Requires the Beta API to enable binary authorization support
 echo "Creating cluster"
-gcloud beta container clusters create "$CLUSTER_NAME" \
+gcloud container clusters create "$CLUSTER_NAME" \
   --zone "$ZONE" \
   --cluster-version "$GKE_VERSION" \
   --machine-type "n1-standard-1" \

--- a/validate.sh
+++ b/validate.sh
@@ -37,7 +37,7 @@ source "$ROOT/common.sh"
 gcloud container clusters get-credentials "$CLUSTER_NAME" --zone "$ZONE"
 
 # Verify BinAuthZ policy is available/enabled
-if gcloud beta container binauthz policy export | grep "defaultAdmissionRule" > /dev/null; then
+if gcloud container binauthz policy export | grep "defaultAdmissionRule" > /dev/null; then
   echo "Validation Passed: a working BinAuthZ policy was available"
 else
   echo "Validation Failed: a working BinAuthZ policy was NOT available"

--- a/validate.sh
+++ b/validate.sh
@@ -45,7 +45,7 @@ else
 fi
 
 # Verify Container Analysis API is available/enabled
-if curl -s -H "Authorization: Bearer $(gcloud auth print-access-token)" "https://containeranalysis.googleapis.com/v1beta1/projects/${PROJECT}/notes/" > /dev/null; then
+if curl -s -H "Authorization: Bearer $(gcloud auth print-access-token)" "https://containeranalysis.googleapis.com/v1/projects/${PROJECT}/notes/" > /dev/null; then
   echo "Validation Passed: the Container Analysis API was available"
 else
   echo "Validation Failed: the Container Analysis API was NOT available"


### PR DESCRIPTION
For details refer Release Notes: https://cloud.google.com/binary-authorization/docs/release-notes

Updates README and Script.

For #27 

Thanks.